### PR TITLE
Improve textarea active styling

### DIFF
--- a/dist/ui.html
+++ b/dist/ui.html
@@ -38,6 +38,11 @@
       padding: 4px;
     }
 
+    textarea:focus-visible {
+      outline: none;
+      border-color: var(--color-border-focus);
+    }
+
     textarea::placeholder {
       color: var(--color-text-tertiary);
     }

--- a/src/ui.html
+++ b/src/ui.html
@@ -38,6 +38,11 @@
       padding: 4px;
     }
 
+    textarea:focus-visible {
+      outline: none;
+      border-color: var(--color-border-focus);
+    }
+
     textarea::placeholder {
       color: var(--color-text-tertiary);
     }


### PR DESCRIPTION
## Summary
- highlight the textarea border when focused using the `--figma-color-border-selected` token

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685c6d206a2c83239da9ad7e77dbb869