### PR TITLE
Support units in CSS variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSS Variables Importer Figma Plugin
 
-This plugin allows you to paste CSS variable definitions and automatically create Figma variables in your file. Both color values (including all CSS color functions) and numeric values are supported.
+This plugin allows you to paste CSS variable definitions and automatically create Figma variables in your file. Both color values (including all CSS color functions) and numeric values are supported. Values with units are imported as numbers, with `rem` values converted to pixels (16px per `1rem`).
 
 ## Development
 

--- a/dist/code.js
+++ b/dist/code.js
@@ -4458,6 +4458,16 @@
             result[name] = { type: "FLOAT", value: num3 };
             continue;
           }
+          const unitMatch = valueStr.match(/^(-?\d*\.?\d+)([a-zA-Z%]+)$/);
+          if (unitMatch) {
+            let num3 = parseFloat(unitMatch[1]);
+            const unit = unitMatch[2].toLowerCase();
+            if (unit === "rem") {
+              num3 *= 16;
+            }
+            result[name] = { type: "FLOAT", value: num3 };
+            continue;
+          }
           const color = parse_default(valueStr);
           if (color) {
             const rgb3 = clampRgb(toRGB(color));

--- a/src/code.ts
+++ b/src/code.ts
@@ -41,6 +41,17 @@ function parseCssVariables(css: string): Record<string, ParsedVar> {
       continue;
     }
 
+    const unitMatch = valueStr.match(/^(-?\d*\.?\d+)([a-zA-Z%]+)$/);
+    if (unitMatch) {
+      let num = parseFloat(unitMatch[1]);
+      const unit = unitMatch[2].toLowerCase();
+      if (unit === 'rem') {
+        num *= 16;
+      }
+      result[name] = { type: 'FLOAT', value: num };
+      continue;
+    }
+
     const color = parse(valueStr);
     if (color) {
       const rgb = clampRgb(toRGB(color));


### PR DESCRIPTION
## Summary
- allow parsing of numeric values with units in CSS variable definitions
- convert `rem` values to pixels
- document unit support

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_685d759d965c8323a0458eed7cc8a534