### PR TITLE
Add automatic Figma variable scope detection

### DIFF
--- a/dist/code.js
+++ b/dist/code.js
@@ -4429,6 +4429,33 @@
         type: "collections",
         collections: figma.variables.getLocalVariableCollections().map((c2) => c2.name)
       });
+      var VARIABLE_SCOPES = [
+        "TEXT_CONTENT",
+        "CORNER_RADIUS",
+        "WIDTH_HEIGHT",
+        "GAP",
+        "ALL_FILLS",
+        "FRAME_FILL",
+        "SHAPE_FILL",
+        "TEXT_FILL",
+        "STROKE_COLOR",
+        "STROKE_FLOAT",
+        "EFFECT_FLOAT",
+        "EFFECT_COLOR",
+        "OPACITY",
+        "FONT_FAMILY",
+        "FONT_STYLE",
+        "FONT_WEIGHT",
+        "FONT_SIZE",
+        "LINE_HEIGHT",
+        "LETTER_SPACING",
+        "PARAGRAPH_SPACING",
+        "PARAGRAPH_INDENT"
+      ];
+      function detectVariableScopes(name) {
+        const normalized = name.replace(/[^a-zA-Z0-9]+/g, "_").toUpperCase();
+        return VARIABLE_SCOPES.filter((scope) => normalized.includes(scope));
+      }
       function toFigmaName(name) {
         const parts = name.split("-");
         if (parts.length > 1) {
@@ -4515,6 +4542,10 @@
             }
             variable.setValueForMode(modeId, data.value);
             variable.setVariableCodeSyntax("WEB", `var(--${cssName})`);
+            const scopes = detectVariableScopes(cssName);
+            if (scopes.length) {
+              variable.scopes = scopes;
+            }
             created[cssName] = variable;
             nameMap.set(cssName, variable);
           }
@@ -4536,6 +4567,10 @@
                 const alias = figma.variables.createVariableAlias(target);
                 variable.setValueForMode(modeId, alias);
                 variable.setVariableCodeSyntax("WEB", `var(--${cssName})`);
+                const scopes = detectVariableScopes(cssName);
+                if (scopes.length) {
+                  variable.scopes = scopes;
+                }
                 created[cssName] = variable;
                 nameMap.set(cssName, variable);
               } else {

--- a/src/code.ts
+++ b/src/code.ts
@@ -9,6 +9,35 @@ figma.ui.postMessage({
 // Helper to parse CSS variable definitions
 type ParsedVar = { type: 'COLOR' | 'FLOAT' | 'ALIAS'; value: any };
 
+const VARIABLE_SCOPES: VariableScope[] = [
+  'TEXT_CONTENT',
+  'CORNER_RADIUS',
+  'WIDTH_HEIGHT',
+  'GAP',
+  'ALL_FILLS',
+  'FRAME_FILL',
+  'SHAPE_FILL',
+  'TEXT_FILL',
+  'STROKE_COLOR',
+  'STROKE_FLOAT',
+  'EFFECT_FLOAT',
+  'EFFECT_COLOR',
+  'OPACITY',
+  'FONT_FAMILY',
+  'FONT_STYLE',
+  'FONT_WEIGHT',
+  'FONT_SIZE',
+  'LINE_HEIGHT',
+  'LETTER_SPACING',
+  'PARAGRAPH_SPACING',
+  'PARAGRAPH_INDENT'
+];
+
+function detectVariableScopes(name: string): VariableScope[] {
+  const normalized = name.replace(/[^a-zA-Z0-9]+/g, '_').toUpperCase();
+  return VARIABLE_SCOPES.filter(scope => normalized.includes(scope));
+}
+
 function toFigmaName(name: string): string {
   const parts = name.split('-');
   if (parts.length > 1) {
@@ -104,6 +133,10 @@ figma.ui.onmessage = async (msg) => {
       }
       variable.setValueForMode(modeId, data.value);
       variable.setVariableCodeSyntax('WEB', `var(--${cssName})`);
+      const scopes = detectVariableScopes(cssName);
+      if (scopes.length) {
+        variable.scopes = scopes;
+      }
       created[cssName] = variable;
       nameMap.set(cssName, variable);
     }
@@ -129,6 +162,10 @@ figma.ui.onmessage = async (msg) => {
           const alias = figma.variables.createVariableAlias(target);
           variable.setValueForMode(modeId, alias);
           variable.setVariableCodeSyntax('WEB', `var(--${cssName})`);
+          const scopes = detectVariableScopes(cssName);
+          if (scopes.length) {
+            variable.scopes = scopes;
+          }
           created[cssName] = variable;
           nameMap.set(cssName, variable);
         } else {


### PR DESCRIPTION
## Summary
- detect intended usage of CSS variables from name
- set Figma variable scopes accordingly when creating variables

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685d7a9a211c8323a8d57d3ee5b20b33