### PR TITLE
Add variable preview UI

### DIFF
--- a/dist/code.js
+++ b/dist/code.js
@@ -4543,6 +4543,17 @@
       }
       figma.ui.onmessage = async (msg) => {
         var _a;
+        if (msg.type === "preview-css") {
+          const vars = parseCssVariables(msg.css);
+          const preview = Object.entries(vars).map(([name, data]) => ({
+            name,
+            type: data.type,
+            value: data.value,
+            scopes: detectVariableScopes(name)
+          }));
+          figma.ui.postMessage({ type: "preview-data", preview });
+          return;
+        }
         if (msg.type === "import-css") {
           const vars = parseCssVariables(msg.css);
           const collectionName = msg.collectionName;

--- a/dist/ui.html
+++ b/dist/ui.html
@@ -85,6 +85,37 @@
       outline: none;
       box-shadow: 0 0 0 2px var(--color-border-focus);
     }
+
+    #preview {
+      margin-top: 12px;
+      max-height: 120px;
+      overflow-y: auto;
+      border-top: 1px solid var(--color-border);
+      padding-top: 8px;
+    }
+
+    .preview-item {
+      display: flex;
+      align-items: center;
+      margin-bottom: 4px;
+    }
+
+    .preview-color {
+      width: 12px;
+      height: 12px;
+      border-radius: 2px;
+      border: 1px solid var(--color-border);
+      margin-right: 6px;
+    }
+
+    .preview-name {
+      flex: 1;
+    }
+
+    .preview-scopes {
+      color: var(--color-text-tertiary);
+      font-size: 11px;
+    }
   </style>
 </head>
 <body>
@@ -96,11 +127,17 @@
   <input id="newCollection" type="text" placeholder="New collection name" style="display:none; width: 100%; margin-top: 4px;" />
   <br />
   <button id="import">Import</button>
+  <div id="preview"></div>
   <script>
     const textarea = document.getElementById('cssInput');
     const importBtn = document.getElementById('import');
     const select = document.getElementById('collectionSelect');
     const newInput = document.getElementById('newCollection');
+    const previewDiv = document.getElementById('preview');
+
+    function sendPreview() {
+      parent.postMessage({ pluginMessage: { type: 'preview-css', css: textarea.value } }, '*');
+    }
 
     function updateButtonState() {
       let disabled = textarea.value.trim().length === 0;
@@ -108,6 +145,7 @@
         disabled = newInput.value.trim().length === 0;
       }
       importBtn.disabled = disabled;
+      sendPreview();
     }
 
     textarea.addEventListener('input', updateButtonState);
@@ -132,6 +170,31 @@
         newOpt.textContent = 'New collection...';
         select.appendChild(newOpt);
         updateButtonState();
+      }
+      if (msg.type === 'preview-data') {
+        previewDiv.innerHTML = '';
+        for (const item of msg.preview) {
+          const div = document.createElement('div');
+          div.className = 'preview-item';
+          const color = document.createElement('div');
+          color.className = 'preview-color';
+          if (item.type === 'COLOR') {
+            const { r, g, b, a } = item.value;
+            color.style.background = `rgba(${Math.round(r*255)}, ${Math.round(g*255)}, ${Math.round(b*255)}, ${a})`;
+          } else {
+            color.style.background = 'transparent';
+          }
+          div.appendChild(color);
+          const name = document.createElement('div');
+          name.className = 'preview-name';
+          name.textContent = item.name;
+          div.appendChild(name);
+          const scopes = document.createElement('div');
+          scopes.className = 'preview-scopes';
+          scopes.textContent = item.scopes.join(', ');
+          div.appendChild(scopes);
+          previewDiv.appendChild(div);
+        }
       }
     };
 

--- a/src/code.ts
+++ b/src/code.ts
@@ -130,6 +130,17 @@ function parseCssVariables(css: string): Record<string, ParsedVar> {
 }
 
 figma.ui.onmessage = async (msg) => {
+  if (msg.type === 'preview-css') {
+    const vars = parseCssVariables(msg.css as string);
+    const preview = Object.entries(vars).map(([name, data]) => ({
+      name,
+      type: data.type,
+      value: data.value,
+      scopes: detectVariableScopes(name)
+    }));
+    figma.ui.postMessage({ type: 'preview-data', preview });
+    return;
+  }
   if (msg.type === 'import-css') {
     const vars = parseCssVariables(msg.css as string);
     const collectionName = msg.collectionName as string;

--- a/src/ui.html
+++ b/src/ui.html
@@ -85,6 +85,37 @@
       outline: none;
       box-shadow: 0 0 0 2px var(--color-border-focus);
     }
+
+    #preview {
+      margin-top: 12px;
+      max-height: 120px;
+      overflow-y: auto;
+      border-top: 1px solid var(--color-border);
+      padding-top: 8px;
+    }
+
+    .preview-item {
+      display: flex;
+      align-items: center;
+      margin-bottom: 4px;
+    }
+
+    .preview-color {
+      width: 12px;
+      height: 12px;
+      border-radius: 2px;
+      border: 1px solid var(--color-border);
+      margin-right: 6px;
+    }
+
+    .preview-name {
+      flex: 1;
+    }
+
+    .preview-scopes {
+      color: var(--color-text-tertiary);
+      font-size: 11px;
+    }
   </style>
 </head>
 <body>
@@ -96,11 +127,17 @@
   <input id="newCollection" type="text" placeholder="New collection name" style="display:none; width: 100%; margin-top: 4px;" />
   <br />
   <button id="import">Import</button>
+  <div id="preview"></div>
   <script>
     const textarea = document.getElementById('cssInput');
     const importBtn = document.getElementById('import');
     const select = document.getElementById('collectionSelect');
     const newInput = document.getElementById('newCollection');
+    const previewDiv = document.getElementById('preview');
+
+    function sendPreview() {
+      parent.postMessage({ pluginMessage: { type: 'preview-css', css: textarea.value } }, '*');
+    }
 
     function updateButtonState() {
       let disabled = textarea.value.trim().length === 0;
@@ -108,6 +145,7 @@
         disabled = newInput.value.trim().length === 0;
       }
       importBtn.disabled = disabled;
+      sendPreview();
     }
 
     textarea.addEventListener('input', updateButtonState);
@@ -132,6 +170,31 @@
         newOpt.textContent = 'New collection...';
         select.appendChild(newOpt);
         updateButtonState();
+      }
+      if (msg.type === 'preview-data') {
+        previewDiv.innerHTML = '';
+        for (const item of msg.preview) {
+          const div = document.createElement('div');
+          div.className = 'preview-item';
+          const color = document.createElement('div');
+          color.className = 'preview-color';
+          if (item.type === 'COLOR') {
+            const { r, g, b, a } = item.value;
+            color.style.background = `rgba(${Math.round(r*255)}, ${Math.round(g*255)}, ${Math.round(b*255)}, ${a})`;
+          } else {
+            color.style.background = 'transparent';
+          }
+          div.appendChild(color);
+          const name = document.createElement('div');
+          name.className = 'preview-name';
+          name.textContent = item.name;
+          div.appendChild(name);
+          const scopes = document.createElement('div');
+          scopes.className = 'preview-scopes';
+          scopes.textContent = item.scopes.join(', ');
+          div.appendChild(scopes);
+          previewDiv.appendChild(div);
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
- let `ui.html` request CSS variable preview
- show preview items with name and detected variable scopes
- handle `preview-css` message in `code.ts`
- build dist

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685d9cf150048323bf94ed7cb40061a6