### PR TITLE
Fix preview crash for alias vars

### DIFF
--- a/dist/code.js
+++ b/dist/code.js
@@ -4491,6 +4491,7 @@
       };
       function filterScopesForType(scopes, type) {
         const allowed = SCOPES_BY_TYPE[type];
+        if (!allowed) return scopes;
         return scopes.filter((s) => allowed.includes(s));
       }
       figma.showUI(__html__, { themeColors: true, width: 400, height: 480 });

--- a/src/code.ts
+++ b/src/code.ts
@@ -71,8 +71,12 @@ const SCOPES_BY_TYPE: Record<'COLOR' | 'FLOAT' | 'STRING' | 'BOOLEAN', VariableS
   BOOLEAN: []
 };
 
-function filterScopesForType(scopes: VariableScope[], type: 'COLOR' | 'FLOAT' | 'STRING' | 'BOOLEAN'): VariableScope[] {
-  const allowed = SCOPES_BY_TYPE[type];
+function filterScopesForType(
+  scopes: VariableScope[],
+  type: 'COLOR' | 'FLOAT' | 'STRING' | 'BOOLEAN' | string
+): VariableScope[] {
+  const allowed = SCOPES_BY_TYPE[type as 'COLOR' | 'FLOAT' | 'STRING' | 'BOOLEAN'];
+  if (!allowed) return scopes;
   return scopes.filter(s => allowed.includes(s));
 }
 


### PR DESCRIPTION
## Summary
- avoid crashing when previewing CSS variables that alias others

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6861a07d00c4832390c413b6459aa363