### PR TITLE
feat: support relative oklch colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSS Variables Importer Figma Plugin
 
-This plugin allows you to paste CSS variable definitions and automatically create Figma variables in your file. Both color values (including all CSS color functions) and numeric values are supported. Values with units are imported as numbers, with `rem` values converted to pixels (16px per `1rem`).
+This plugin allows you to paste CSS variable definitions and automatically create Figma variables in your file. Both color values (including all CSS color functions, even relative color syntax such as `oklch(from var(--base) 0.9 0.1 h)`) and numeric values are supported. Values with units are imported as numbers, with `rem` values converted to pixels (16px per `1rem`).
 
 ## Development
 


### PR DESCRIPTION
## Summary
- handle OKLCH relative color syntax using `from var()` and optional hue shifts
- document support for relative color definitions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688f87b6b2ec83239f97e94d5dbfa9a9