### PR TITLE
Fix OKLCH relative color base conversion

### DIFF
--- a/dist/code.js
+++ b/dist/code.js
@@ -4574,7 +4574,11 @@
             const hStr = relativeMatch[4];
             const base = result[baseName];
             if (base && base.type === "COLOR") {
-              const baseOklch = toOKLCH(__spreadProps(__spreadValues({}, base.value), { alpha: base.value.a }));
+              const baseOklch = toOKLCH(__spreadProps(__spreadValues({
+                mode: "rgb"
+              }, base.value), {
+                alpha: base.value.a
+              }));
               const parseChannel = (str, baseVal, letter) => {
                 if (str === letter) return baseVal;
                 if (str.endsWith("%")) return parseFloat(str) / 100;

--- a/dist/ui.html
+++ b/dist/ui.html
@@ -21,7 +21,7 @@
     .container {
       display: flex;
       flex-direction: column;
-      height: 100vh;
+      min-height: 100vh;
       background: var(--figma-color-bg);
     }
     .input-section {
@@ -155,7 +155,7 @@
   </style>
 </head>
 <body>
-  <div class="container flex">
+  <div class="container">
     <div class="input-section">
       <textarea class="css-input-box" id="cssInput" placeholder="--primary: #ff0000;\n--spacing: 8px;"></textarea>
       <div style="display: flex; gap: 8px; align-items: center; margin-top: 8px;">

--- a/src/code.ts
+++ b/src/code.ts
@@ -167,7 +167,11 @@ function parseCssVariables(css: string): Record<string, ParsedVar> {
       const hStr = relativeMatch[4];
       const base = result[baseName];
       if (base && base.type === 'COLOR') {
-        const baseOklch = toOKLCH({ ...base.value, alpha: base.value.a });
+        const baseOklch = toOKLCH({
+          mode: 'rgb',
+          ...base.value,
+          alpha: base.value.a
+        });
         const parseChannel = (str: string, baseVal: number, letter: string): number => {
           if (str === letter) return baseVal;
           if (str.endsWith('%')) return parseFloat(str) / 100;


### PR DESCRIPTION
## Summary
- ensure relative OKLCH colors convert base RGB values with explicit mode
- rebuild plugin distribution files

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688f8ae5ce088323a17c539360188239