### PR TITLE
Remove group prefix from preview names

### DIFF
--- a/dist/ui.html
+++ b/dist/ui.html
@@ -370,7 +370,14 @@
           // Name
           const nameDiv = document.createElement('div');
           nameDiv.className = 'variable-name';
-          nameDiv.textContent = item.name;
+          let displayName = item.name;
+          if (groupName) {
+            const prefix = groupName.replace(/\//g, '-') + '-';
+            if (displayName.startsWith(prefix)) {
+              displayName = displayName.slice(prefix.length);
+            }
+          }
+          nameDiv.textContent = displayName;
           infoDiv.appendChild(nameDiv);
           
           // Description (if any)

--- a/src/ui.html
+++ b/src/ui.html
@@ -370,7 +370,14 @@
           // Name
           const nameDiv = document.createElement('div');
           nameDiv.className = 'variable-name';
-          nameDiv.textContent = item.name;
+          let displayName = item.name;
+          if (groupName) {
+            const prefix = groupName.replace(/\//g, '-') + '-';
+            if (displayName.startsWith(prefix)) {
+              displayName = displayName.slice(prefix.length);
+            }
+          }
+          nameDiv.textContent = displayName;
           infoDiv.appendChild(nameDiv);
           
           // Description (if any)


### PR DESCRIPTION
## Summary
- Strip group names from preview variable labels so items don't repeat their group name

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6894e2c8402c8323bc7d3430cd679ef8