### PR TITLE
Restore collection picker in UI

### DIFF
--- a/dist/ui.html
+++ b/dist/ui.html
@@ -148,6 +148,7 @@
       display: flex;
       justify-content: flex-end;
       background: var(--figma-color-bg);
+      margin-top: auto;
     }
     .primary-btn {
       background: var(--figma-color-bg-brand);
@@ -194,7 +195,7 @@
     <div class="main-content">
       <div class="left-panel">
         <textarea class="css-input-box" id="cssInput" placeholder="--grey-50: #E7E8E7;&#10;--grey-100: #d7d7d7;&#10;--grey-200: #b9bab9;&#10;--grey-300: #9FA09F;&#10;&#10;&#10;--color-surface-secondary:var(--grey-100);  /* secondary neutral surface        */&#10;--color-surface-tertiary:var(--grey-200);  /* tertiary neutral surface         */&#10;--color-surface-emphasis:var(--grey-300);  /* highest-contrast neutral surface */"></textarea>
-        <div style="display: none; gap: 8px; align-items: center; margin-top: 8px;">
+        <div style="display: flex; gap: 8px; align-items: center; margin-top: 8px;">
           <label for="collectionSelect" style="font-size: 11px; color: var(--figma-color-text-tertiary);">Collection:</label>
           <select id="collectionSelect" style="flex: 1;"></select>
           <input id="newCollection" type="text" placeholder="New collection name" style="display:none; width: 160px; font-size: 11px; margin-left: 8px;" />
@@ -431,6 +432,7 @@
         newOpt.textContent = 'New collection...';
         select.appendChild(newOpt);
         scopes = msg.scopes;
+        newInput.style.display = select.value === '__new__' ? 'block' : 'none';
         updateButtonState();
         
         // Request optimal window size based on content

--- a/src/ui.html
+++ b/src/ui.html
@@ -195,7 +195,7 @@
     <div class="main-content">
       <div class="left-panel">
         <textarea class="css-input-box" id="cssInput" placeholder="--grey-50: #E7E8E7;&#10;--grey-100: #d7d7d7;&#10;--grey-200: #b9bab9;&#10;--grey-300: #9FA09F;&#10;&#10;&#10;--color-surface-secondary:var(--grey-100);  /* secondary neutral surface        */&#10;--color-surface-tertiary:var(--grey-200);  /* tertiary neutral surface         */&#10;--color-surface-emphasis:var(--grey-300);  /* highest-contrast neutral surface */"></textarea>
-        <div style="display: none; gap: 8px; align-items: center; margin-top: 8px;">
+        <div style="display: flex; gap: 8px; align-items: center; margin-top: 8px;">
           <label for="collectionSelect" style="font-size: 11px; color: var(--figma-color-text-tertiary);">Collection:</label>
           <select id="collectionSelect" style="flex: 1;"></select>
           <input id="newCollection" type="text" placeholder="New collection name" style="display:none; width: 160px; font-size: 11px; margin-left: 8px;" />
@@ -432,6 +432,7 @@
         newOpt.textContent = 'New collection...';
         select.appendChild(newOpt);
         scopes = msg.scopes;
+        newInput.style.display = select.value === '__new__' ? 'block' : 'none';
         updateButtonState();
         
         // Request optimal window size based on content


### PR DESCRIPTION
## Summary
- Make the collection picker visible in the interface so variables can be assigned to an existing or new collection
- Automatically reveal the text input for creating a collection when "New collection" is selected or no collections exist

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689507f6a2848323a9c58e077854ee43