### PR TITLE
Gracefully handle missing Figma variable APIs

### DIFF
--- a/dist/code.js
+++ b/dist/code.js
@@ -4495,11 +4495,14 @@
         return scopes.filter((s) => allowed.includes(s));
       }
       async function getAllLocalVariables() {
+        if (!figma.variables || typeof figma.variables.getLocalVariableCollections !== "function" || typeof figma.variables.getLocalVariablesForCollectionAsync !== "function") {
+          return [];
+        }
         const collections = figma.variables.getLocalVariableCollections();
         const perCollection = await Promise.all(
-          collections.map((c2) => figma.variables.getLocalVariablesForCollectionAsync(c2))
+          Array.isArray(collections) ? collections.map((c2) => figma.variables.getLocalVariablesForCollectionAsync(c2)) : []
         );
-        return perCollection.flat();
+        return [].concat(...perCollection);
       }
       figma.showUI(__html__, { themeColors: true, width: 900, height: 600 });
       figma.ui.postMessage({

--- a/src/code.ts
+++ b/src/code.ts
@@ -87,11 +87,20 @@ function filterScopesForType(
 }
 
 async function getAllLocalVariables(): Promise<Variable[]> {
+  if (
+    !figma.variables ||
+    typeof figma.variables.getLocalVariableCollections !== 'function' ||
+    typeof figma.variables.getLocalVariablesForCollectionAsync !== 'function'
+  ) {
+    return [];
+  }
   const collections = figma.variables.getLocalVariableCollections();
   const perCollection = await Promise.all(
-    collections.map(c => figma.variables.getLocalVariablesForCollectionAsync(c))
+    Array.isArray(collections)
+      ? collections.map(c => figma.variables.getLocalVariablesForCollectionAsync(c))
+      : []
   );
-  return perCollection.flat();
+  return ([] as Variable[]).concat(...perCollection);
 }
 
 figma.showUI(__html__, { themeColors: true, width: 900, height: 600 });


### PR DESCRIPTION
## Summary
- Guard against missing Figma variable APIs before enumerating collections
- Replace Array.flat with concat for broader compatibility

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6895342777e483238c7ae2a31875a91c